### PR TITLE
Update resources menu padding and add hr styling

### DIFF
--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -7,7 +7,14 @@ import {
 } from "@mdi/js";
 import Icon from "@mdi/react";
 import Link from "next/link";
-import { FC, MouseEvent, PropsWithChildren, useCallback, useState } from "react";
+import {
+  FC,
+  Fragment,
+  MouseEvent,
+  PropsWithChildren,
+  useCallback,
+  useState,
+} from "react";
 
 import { RESOURCE_LINKS } from "@/data/resources";
 import { useShare } from "@/hooks/useShare";
@@ -83,7 +90,7 @@ const titleCss = css`
 `;
 
 const resourcesMenuCss = css`
-  padding: 5px;
+  padding: 10px;
   display: flex;
   flex-direction: column;
   gap: 5px;
@@ -145,14 +152,16 @@ export const TopNav: FC<Props> = ({ children, isResource, onShare }) => {
                 onClickOutside={() => setIsResourcesMenuOpen(false)}
               >
                 {RESOURCE_LINKS.map(({ label, href, shallow }) => (
-                  <Link
-                    key={href}
-                    href={href}
-                    {...(shallow ? { shallow: true } : {})}
-                    onClick={() => setIsResourcesMenuOpen(false)}
-                  >
-                    {label}
-                  </Link>
+                  <Fragment key={href}>
+                    <Link
+                      href={href}
+                      {...(shallow ? { shallow: true } : {})}
+                      onClick={() => setIsResourcesMenuOpen(false)}
+                    >
+                      {label}
+                    </Link>
+                    {label === "Timeline" && <hr />}
+                  </Fragment>
                 ))}
               </FloatingBox>
             )}

--- a/src/styles/globalCss.ts
+++ b/src/styles/globalCss.ts
@@ -149,4 +149,10 @@ export const globalCss = css`
     border-radius: 3px;
     padding: 2px 4px;
   }
+
+  hr {
+    height: 1px;
+    border: none;
+    background-color: var(--border-color);
+  }
 `;


### PR DESCRIPTION
## Summary
- tweak Resources menu padding in the TopNav
- insert a separator before the Source Code link
- add global styling for `<hr>`

## Testing
- `yarn lint`
- `yarn tsc --noEmit`