### PR TITLE
Fix reading history menu on mobile

### DIFF
--- a/src/components/ReadingNav.tsx
+++ b/src/components/ReadingNav.tsx
@@ -198,6 +198,7 @@ export const ReadingNav: FC<Props> = ({
 
       {isReadingHistoryMenuOpen && (
         <FloatingBox
+          shouldMaximizeOnMobile
           css={readingHistoryMenuCss}
           onClickOutside={onCloseReadingHistoryMenu}
         >


### PR DESCRIPTION
## Summary
- expand the reading history menu on mobile

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install --immutable` *(fails: Bad response 403)*

------
https://chatgpt.com/codex/tasks/task_b_6883f15eeec48330823b755761e4562c