### PR TITLE
Disable tooltips on mobile

### DIFF
--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -3,6 +3,7 @@ import { FC } from "react";
 
 import { shadows } from "@/styles/shadows";
 import { transition } from "@/styles/transition";
+import { breakpoints } from "@/styles/breakpoints";
 
 type TooltipPlacement = "top" | "bottom" | "left" | "right";
 
@@ -75,6 +76,9 @@ const tooltipCss = (placement: TooltipPlacement = "bottom") => css`
   transition: ${transition("opacity", "visibility")};
   box-shadow: ${shadows["shadow-lg"]};
   ${getPlacementStyles(placement)}
+  @media ${breakpoints["is-mobile"]} {
+    display: none;
+  }
 `;
 
 export const Tooltip: FC<TooltipProps> = ({


### PR DESCRIPTION
## Summary
- hide `Tooltip` component on small screens using the existing `is-mobile` breakpoint

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn typecheck` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_b_688451a6b6908330ae38a1f61613320d