### PR TITLE
Search: add first-mention results, debounce queries, and dedupe history

### DIFF
--- a/src/components/Search/SearchController.tsx
+++ b/src/components/Search/SearchController.tsx
@@ -73,7 +73,9 @@ export const SearchController: FC<Props> = ({
   const [searchHistory, setSearchHistory] = useTextSearchHistory();
 
   const performSearch = useCallback(
-    async (query: string) => {
+    async (query: string, options: { saveToHistory?: boolean } = {}) => {
+      const { saveToHistory = true } = options;
+
       // Don't search for empty queries
       if (query.trim().length === 0) {
         setHasSearched(false);
@@ -81,10 +83,12 @@ export const SearchController: FC<Props> = ({
         return;
       }
 
-      setSearchHistory((previous) => [
-        { query, timestamp: Date.now() },
-        ...previous,
-      ]);
+      if (saveToHistory) {
+        setSearchHistory((previous) => [
+          { query, timestamp: Date.now() },
+          ...previous.filter((entry) => entry.query !== query),
+        ]);
+      }
 
       setResults([]);
       setIsLoading(true);
@@ -104,6 +108,22 @@ export const SearchController: FC<Props> = ({
     [setSearchHistory]
   );
 
+  useEffect(() => {
+    const trimmedQuery = query.trim();
+
+    if (trimmedQuery.length < 2) {
+      setHasSearched(false);
+      setResults([]);
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      performSearch(trimmedQuery, { saveToHistory: false });
+    }, 200);
+
+    return () => clearTimeout(timeoutId);
+  }, [query, performSearch]);
+
   const onClearSearchHistory = useCallback(() => {
     setSearchHistory([]);
   }, [setSearchHistory]);
@@ -116,7 +136,7 @@ export const SearchController: FC<Props> = ({
     async (event: FormEvent) => {
       event.preventDefault();
 
-      await performSearch(query);
+      await performSearch(query, { saveToHistory: true });
     },
     [query, performSearch]
   );
@@ -136,7 +156,7 @@ export const SearchController: FC<Props> = ({
         inputRef.current.focus();
       }
 
-      await performSearch(query);
+      await performSearch(query, { saveToHistory: true });
     },
     [performSearch]
   );
@@ -255,7 +275,7 @@ export const SearchController: FC<Props> = ({
 
         <div css={searchResultsContainerCss}>
           {results.map((result, index) => (
-            <SearchResultDisplay key={index} {...result} onClick={onClose} />
+            <SearchResultDisplay key={index} result={result} onClick={onClose} />
           ))}
         </div>
       </Overlay>

--- a/src/components/Search/SearchResultDisplay.tsx
+++ b/src/components/Search/SearchResultDisplay.tsx
@@ -1,27 +1,53 @@
+import { css } from "@emotion/react";
 import Link from "next/link";
 import { FC } from "react";
 
-import { Verse } from "@/types";
+import { SearchResult } from "@/types";
 import { getRouteFromBookAndChapter } from "@/utils/getRouteFromBookAndChapter";
 
-interface Props extends Verse {
+interface Props {
+  result: SearchResult;
   onClick: () => void;
 }
 
-export const SearchResultDisplay: FC<Props> = ({
-  book,
-  chapter,
-  verse,
-  text,
-  onClick,
-}) => (
-  <div>
-    <Link
-      href={getRouteFromBookAndChapter(book, chapter, verse)}
-      onClick={onClick}
-    >
-      {book} {chapter}:{verse}
-    </Link>
-    <div>{text}</div>
-  </div>
-);
+const headerCss = css`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+`;
+
+const firstMentionPillCss = css`
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 1px 8px;
+`;
+
+export const SearchResultDisplay: FC<Props> = ({ result, onClick }) => {
+  const { verse } = result;
+
+  return (
+    <div>
+      <div css={headerCss}>
+        <Link
+          href={getRouteFromBookAndChapter(
+            verse.book,
+            verse.chapter,
+            verse.verse
+          )}
+          onClick={onClick}
+        >
+          {verse.book} {verse.chapter}:{verse.verse}
+        </Link>
+
+        {result.kind === "first-mention" && (
+          <small css={firstMentionPillCss} data-muted>
+            First mention: {result.word}
+          </small>
+        )}
+      </div>
+
+      <div>{verse.text}</div>
+    </div>
+  );
+};

--- a/src/data/getFirstMentionSearchResults.ts
+++ b/src/data/getFirstMentionSearchResults.ts
@@ -1,0 +1,45 @@
+import { flatten, isUndefined, keys, take } from "lodash";
+
+import { getFirstMentionIndex } from "@/data/getFirstMentionIndex";
+import { Verse } from "@/types";
+import { stemWord } from "@/utils/stemWord";
+
+import { normalizeQuery } from "./normalizeQuery";
+
+type Options = {
+  limit: string | string[] | undefined;
+};
+
+type Result = {
+  word: string;
+  verse: Verse;
+};
+
+const DEFAULT_LIMIT = "5";
+
+export const getFirstMentionSearchResults = (
+  query: string | string[] | undefined,
+  { limit = DEFAULT_LIMIT }: Options
+): Result[] => {
+  if (isUndefined(query)) {
+    return [];
+  }
+
+  const normalizedQuery = normalizeQuery(query);
+  if (normalizedQuery.length === 0) {
+    return [];
+  }
+
+  const index = getFirstMentionIndex();
+  const queryWords = normalizedQuery.split(" ").map(stemWord);
+  const parsedLimit = parseInt(flatten([limit])[0] ?? DEFAULT_LIMIT, 10);
+
+  const matchingKeys = keys(index).filter((key) =>
+    queryWords.some((word) => key.includes(word))
+  );
+
+  return take(matchingKeys, parsedLimit).map((word) => ({
+    word,
+    verse: index[word],
+  }));
+};

--- a/src/pages/api/search.ts
+++ b/src/pages/api/search.ts
@@ -2,6 +2,7 @@ import { get } from "lodash";
 import type { NextApiRequest, NextApiResponse } from "next";
 
 import { getSemanticSearchResults } from "@/data/getSemanticSearchResults";
+import { getFirstMentionSearchResults } from "@/data/getFirstMentionSearchResults";
 import { getTextSearchResults } from "@/data/getTextSearchResults";
 
 type Result = unknown;
@@ -15,12 +16,27 @@ export default async function handler(
   try {
     console.log(`Searching for "${query}"`);
 
-    const [textResults, semanticResults] = await Promise.all([
+    const [textResults, semanticResults, firstMentionResults] = await Promise.all([
       getTextSearchResults(query, { limit }),
       getSemanticSearchResults(query),
+      getFirstMentionSearchResults(query, { limit: "5" }),
     ]);
 
-    const results = [...semanticResults, ...textResults];
+    const results = [
+      ...firstMentionResults.map((result) => ({
+        kind: "first-mention" as const,
+        word: result.word,
+        verse: result.verse,
+      })),
+      ...semanticResults.map((result) => ({
+        kind: "verse" as const,
+        verse: result,
+      })),
+      ...textResults.map((result) => ({
+        kind: "verse" as const,
+        verse: result,
+      })),
+    ];
 
     res.status(200).json({ results });
   } catch (error: unknown) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,18 @@ export type SearchHistoryEntry = {
 
 export type SearchHistory = SearchHistoryEntry[];
 
-export type SearchResult = Verse;
+export type VerseSearchResult = {
+  kind: "verse";
+  verse: Verse;
+};
+
+export type FirstMentionSearchResult = {
+  kind: "first-mention";
+  word: string;
+  verse: Verse;
+};
+
+export type SearchResult = VerseSearchResult | FirstMentionSearchResult;
 
 export type SearchResults = SearchResult[];
 


### PR DESCRIPTION
### Motivation
- Surface "first mention" matches alongside semantic and text results to improve discovery of word introductions. 
- Reduce unnecessary API calls by debouncing the search input and avoiding autosaving transient queries to history. 
- Keep search history compact by deduplicating repeated queries when saving. 

### Description
- Add a new data helper `getFirstMentionSearchResults` and wire it into the API so results include a `kind` discriminator (`first-mention` or `verse`).
- Extend types with `FirstMentionSearchResult` and `VerseSearchResult` and update `SearchResult` and `SearchResponse` accordingly.
- Update `SearchController` to debounce `query` changes with a 200ms delay, change `performSearch` to accept an `options` flag to skip saving to history, and dedupe history entries when saving.
- Update `SearchResultDisplay` to accept a `result` object and render a small pill for `first-mention` results while keeping verse links and text rendering.

### Testing
- Ran TypeScript compilation via `yarn build` to validate types and it completed without errors.
- Ran linting via `yarn lint` and it reported no new issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f8ddaa6ce883308b235ce3556996eb)